### PR TITLE
Update ctournament.js

### DIFF
--- a/static/js/ctournament.js
+++ b/static/js/ctournament.js
@@ -77,7 +77,7 @@ function ui_list() {
 		list_show(response.tournaments);
 	});
 }
-crouting.register(/t\/$/, ui_list, change.default_handler);
+crouting.register(/^t\/$/, ui_list, change.default_handler);
 
 function list_show(tournaments) {
 	const main = uiu.qs('.main');


### PR DESCRIPTION
Der reguläre Ausdruck hat leider auch auf Turniere gemachted, die mit t enden, weshalb wir immer ein Problem hatten mit unserem Testturnier t/btstest/, dass das automatische aktualisieren und das Neuladen der Seite nicht funktioniert hat.