### PR TITLE
Update crouting.js

### DIFF
--- a/static/js/crouting.js
+++ b/static/js/crouting.js
@@ -90,6 +90,7 @@ function rerender() {
 
 function _set_path(new_path) {
 	history.pushState(null, '', new_path);
+	_load(new_path);
 }
 
 function init() {


### PR DESCRIPTION
history.pushState legt zwar den Pfad auf die History und löst beim späteren Betätigen des Zurück Buttons die richtige Route aus. Das Problem ist jedoch, wenn ich von den Turnieren auf ein spezielles Turnier gehe, wird die Route nicht aktiviert und deshalb die automatischen Updates auch nicht. Erst nach Neuladen der Seite funktioniert alles, weil dann die richtige Route geladen wird. Diese Änderung behebt das Problem.