### PR TITLE
Make counting configurable

### DIFF
--- a/bts/admin.js
+++ b/bts/admin.js
@@ -54,7 +54,7 @@ function handle_tournament_edit_props(app, ws, msg) {
 		'name',
 		'btp_enabled', 'btp_autofetch_enabled', 'btp_readonly',
 		'btp_ip', 'btp_password',
-		'is_team', 'is_nation_competition', 'only_now_on_court',
+		'is_team', 'is_nation_competition', 'only_now_on_court', 'counting',
 		'ticker_enabled', 'ticker_url', 'ticker_password',
 		'language', 'dm_style',
 		'logo_background_color', 'logo_foreground_color']);

--- a/bts/http_api.js
+++ b/bts/http_api.js
@@ -44,6 +44,9 @@ function create_match_representation(tournament, match) {
 	setup.match_id = 'bts_' + match._id;
 	setup.team_competition = tournament.is_team;
 	setup.nation_competition = tournament.is_nation_competition;
+	if (tournament.counting) {
+		setup.counting = tournament.counting;
+	}
 	for (const t of setup.teams) {
 		if (!t.players) continue;
 

--- a/static/js/ci18n_de.js
+++ b/static/js/ci18n_de.js
@@ -51,6 +51,7 @@ var ci18n_de = {
 'tournament:edit:courts': 'Felder:',
 'tournament:edit:dm_style': 'Standard-Ansicht:',
 'tournament:edit:only_now_on_court': 'Spiele müssen auf Feld gezogen werden',
+'tournament:edit:counting': 'Zählweise:',
 'tournament:edit:btp:enabled': 'BTP-Anbindung aktivieren',
 'tournament:edit:btp:autofetch_enabled': 'Automatisch synchronisieren',
 'tournament:edit:btp:readonly': 'Nur lesen',

--- a/static/js/ci18n_en.js
+++ b/static/js/ci18n_en.js
@@ -51,6 +51,7 @@ var ci18n_en = {
 'tournament:edit:courts': 'Courts:',
 'tournament:edit:dm_style': 'Default display style:',
 'tournament:edit:only_now_on_court': 'Matches have to be dragged onto court',
+'tournament:edit:counting': 'Scoring system:',
 'tournament:edit:btp:enabled': 'Enable BTP synchronization',
 'tournament:edit:btp:autofetch_enabled': 'Automatic synchronization',
 'tournament:edit:btp:readonly': 'Read only',

--- a/static/js/ctournament.js
+++ b/static/js/ctournament.js
@@ -360,6 +360,36 @@ function ui_edit() {
 	uiu.el(only_now_on_court_label, 'input', attrs);
 	uiu.el(only_now_on_court_label, 'span', {}, ci18n('tournament:edit:only_now_on_court'));
 
+	// Scoring system
+	const counting_label = uiu.el(form, 'label');
+	uiu.el(counting_label, 'span', {}, ci18n('tournament:edit:counting'));
+	const counting_select = uiu.el(counting_label, 'select', {
+		name: 'counting',
+	});
+	const ALL_COUNTING_OPTIONS = [
+		'3x21',
+		'5x11_15',
+		'5x11_15^90',
+		'5x11_15~NLA',
+		'5x11/3',
+		'5x11_11',
+		'3x11_15',
+		'3x15_18',
+		'2x21+11',
+		'1x21',
+		'1x11_15',
+	];
+	for (const value of ALL_COUNTING_OPTIONS) {
+		const option_attrs = {
+			value,
+		};
+		if (value === curt.counting) {
+			option_attrs.selected = 'selected';
+		}
+		// TODO include bup i18n, get translation from (`settings:counting|${value}`);
+		uiu.el(counting_select, 'option', option_attrs, value);
+	}
+
 	// BTP
 	const btp_fieldset = uiu.el(form, 'fieldset');
 	const btp_enabled_label = uiu.el(btp_fieldset, 'label');
@@ -479,6 +509,7 @@ function ui_edit() {
 			btp_ip: data.btp_ip,
 			btp_password: data.btp_password,
 			btp_timezone: data.btp_timezone,
+			counting: data.counting,
 			dm_style: data.dm_style,
 			ticker_enabled: (!! data.ticker_enabled),
 			ticker_url: data.ticker_url,


### PR DESCRIPTION
Allow users to set the scoring system per tournament.

It seems BTP's data is a bit misleading:
```json
{"ScoringFormat": [{
  "ID": [1],
  "Name": ["3 x 21 Punkte"],
  "NumSets": [3],
  "SetType": [0],
  "LastSetType": [0],
  "Score": [21],
  "IsDefault": [true]
}, {
  "ID": [2],
  "Name": ["5x11"],
  "NumSets": [5],
  "SetType": [301],
  "LastSetType": [301],
  "Score": [21],
  "IsDefault": [false]
}
}
```

`Score` is always 21! So actually we probably need to detect it from the name if anything.

For now, just hardcode it, as it was an urgent request.
